### PR TITLE
Use pointers to icub-os-files

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,6 @@ workspaceLocation: "."
 tasks:
 - command: start-vnc-session.sh
 - command: gp await-port 6080 && gp preview $(gp url 6080)
-- command: cd ${HOME} && wget -O .bashrc_iCub https://git.robotology.eu/MBrunettini/icub-environment/-/raw/master/bashrc_iCub_superbuild
+- command: cd ${HOME} && wget -O .bashrc_iCub https://raw.githubusercontent.com/icub-tech-iit/icub-os-files/master/user-environment/bashrc_iCub_superbuild
 - command: cd ~ && printf "if [ -f ~/.bashrc_iCub ]; then\n . ~/.bashrc_iCub\nfi" | cat - ~/.bashrc > temp && mv temp ~/.bashrc && source ~/.bashrc && cd -
 - command: cd ~ && printf "export OBJ_SUBDIR=build\n" | cat - ~/.bashrc > temp && mv temp ~/.bashrc && source ~/.bashrc && cd -

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The operating system contained in the `icub-head`/`pc104` is tipically installed
 check the relevant documentation at https://icub-tech-iit.github.io/documentation/icub_operating_systems/pc104/icub-live/.
 
 On this machine, in `/home/icub/.bashrc_iCub` a script containing several enviroment variables definitions is provided. If you want to  migrate to use
-the robotology-superbuild, you need to remove the existing `.bashrc_iCub` file, and substitute it with the one provided in https://git.robotology.eu/MBrunettini/icub-environment/raw/master/bashrc_iCub_superbuild.
+the robotology-superbuild, you need to remove the existing `.bashrc_iCub` file, and substitute it with the one provided in https://github.com/icub-tech-iit/icub-os-files/blob/master/user-environment/bashrc_iCub_superbuild.
 
 After you modified the `.bashrc_iCub` script, reboot the computer and  in a new shell check che values of the `ROBOTOLOGY_SUPERBUILD_SOURCE_DIR` and `YARP_ROBOT_NAME` env variables.
 If `ROBOTOLOGY_SUPERBUILD_SOURCE_DIR` contains `/usr/local/src/robot/robotology-superbuild`, and `YARP_ROBOT_NAME` contains the string specific to your robot,
@@ -175,7 +175,7 @@ Most of the existing documentation regarding the installation of the software on
 | http://wiki.icub.org/wiki/MacOSX:_installation  |  http://wiki.icub.org/wiki/MacOS:Installation_from_sources_using_the_robotology-superbuild |  
 | http://wiki.icub.org/wiki/ICub_server_laptop_installation_instructions | Change the last code box in section http://wiki.icub.org/wiki/ICub_server_laptop_installation_instructions#Software_repositories to `git clone https://github.com/robotology/robotology-superbuild.git` | 
 | http://wiki.icub.org/wiki/Compilation_on_the_pc104 | https://wiki.icub.org/wiki/Compilation_on_the_pc104/icub-head_with_the_robotology-superbuild  | 
-| https://git.robotology.eu/MBrunettini/icub-environment/raw/master/home/bashrc_iCub |  https://git.robotology.eu/MBrunettini/icub-environment/raw/master/home/bashrc_iCub_superbuild |
+| https://github.com/icub-tech-iit/icub-os-files/blob/master/user-environment/bashrc_iCub | https://github.com/icub-tech-iit/icub-os-files/blob/master/user-environment/bashrc_iCub_superbuild |
 
 ## FAQ 🙋🏻‍♂️ 
 


### PR DESCRIPTION
This PR replaces pointers to iCub_bash files hosted in the old repo w/ pointers to the brand new [`icub-tech-iit/icub-of-files`](https://github.com/icub-tech-iit/icub-os-files).