### PR TITLE
Remove manual TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,7 @@ How to Install Laptops for iCub (PROTO) Setup
 =============================================
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/icub-tech-iit/icub-setup-installation)
-## TOC 📑
-* [Assignment 👨‍🏫](#assignment-)
-* [Introduction ℹ](#introduction-%E2%84%B9)
-* [Prepare your system :gear:](#prepare-your-system-gear)
-  + [Env variables 🌐](#env-variables-)
-  + [Dependencies :books:](#dependencies-books)
-* [Get software source code, compile and install - `icub-head` :robot:](#get-software-source-code-compile-and-install---icub-head-robot)
-* [Get software source code, compile and install - `icubsrv` :computer:](#get-software-source-code-compile-and-install---icubsrv-computer)
-* [Folder tree of robotology-superbuild 🌿](#folder-tree-of-robotology-superbuild-herb)
-* [Run the software :rocket:](#run-the-software-rocket)
-* [Existing Wiki Documentation 👓](#existing-wiki-documentation-)
-* [FAQ 🙋🏻‍♂️](#faq-%EF%B8%8F)
+
 ## Assignment 👨‍🏫
 
 Open the gitpod :point_up: and install the `robotology-superbuild` following the instructions for the setup of [`icub-head`](https://github.com/icub-tech-iit/icub-setup-installation#get-software-source-code-compile-and-install---icub-head-robot) and then for the setup of [`icubsrv`](https://github.com/icub-tech-iit/icub-setup-installation#get-software-source-code-compile-and-install---icubsrv-computer).


### PR DESCRIPTION
TOC is no longer required given that we have now available a brand new option for that, which is enabled by default (see below):

![image](https://user-images.githubusercontent.com/3738070/112726497-16d85800-8f1e-11eb-94df-3bc5e357206a.png)
